### PR TITLE
Allow paths to be specified for certain commands

### DIFF
--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -41,7 +41,7 @@ jobs:
       -
         name: 'PHP-CS-Fixer (fix)'
         # config uses base of caller module
-        run: vendor/bin/php-cs-fixer fix --ansi --no-interaction --config vendor/nswdpc/ci-files/php-cs-fixer/.php-cs-fixer.php
+        run: vendor/bin/php-cs-fixer fix --ansi --no-interaction --config vendor/nswdpc/ci-files/php-cs-fixer/.php-cs-fixer.php src tests
 
       -
         # commit only to core contributors who have repository access

--- a/.github/workflows/php-cs-fixer_83.yml
+++ b/.github/workflows/php-cs-fixer_83.yml
@@ -41,7 +41,7 @@ jobs:
       -
         name: 'PHP-CS-Fixer (fix)'
         # config uses base of caller module
-        run: vendor/bin/php-cs-fixer fix --ansi --no-interaction --config vendor/nswdpc/ci-files/php-cs-fixer/.php-cs-fixer.php
+        run: vendor/bin/php-cs-fixer fix --ansi --no-interaction --config vendor/nswdpc/ci-files/php-cs-fixer/.php-cs-fixer.php src tests
 
       -
         # commit only to core contributors who have repository access

--- a/.github/workflows/php-cs-fixer_84.yml
+++ b/.github/workflows/php-cs-fixer_84.yml
@@ -41,7 +41,7 @@ jobs:
       -
         name: 'PHP-CS-Fixer (fix)'
         # config uses base of caller module
-        run: vendor/bin/php-cs-fixer fix --ansi --no-interaction --config vendor/nswdpc/ci-files/php-cs-fixer/.php-cs-fixer.php
+        run: vendor/bin/php-cs-fixer fix --ansi --no-interaction --config vendor/nswdpc/ci-files/php-cs-fixer/.php-cs-fixer.php src tests
 
       -
         # commit only to core contributors who have repository access

--- a/.github/workflows/rector.silverstripe.yml
+++ b/.github/workflows/rector.silverstripe.yml
@@ -42,7 +42,7 @@ jobs:
       -
         name: 'Rector (process)'
         # config uses base of caller module
-        run: vendor/bin/rector process --no-diffs --ansi --config vendor/nswdpc/ci-files/rector/.rector.silverstripe.php
+        run: vendor/bin/rector process --no-diffs --ansi --config vendor/nswdpc/ci-files/rector/.rector.silverstripe.php src tests
 
       -
         # commit only to core contributors who have repository access

--- a/.github/workflows/rector.silverstripe_53_83.yml
+++ b/.github/workflows/rector.silverstripe_53_83.yml
@@ -42,7 +42,7 @@ jobs:
       -
         name: 'Rector (process)'
         # config uses base of caller module
-        run: vendor/bin/rector process --no-diffs --ansi --config vendor/nswdpc/ci-files/rector/.rector.silverstripe_53_83.php
+        run: vendor/bin/rector process --no-diffs --ansi --config vendor/nswdpc/ci-files/rector/.rector.silverstripe_53_83.php src tests
 
       -
         # commit only to core contributors who have repository access

--- a/.github/workflows/rector.silverstripe_5_81.yml
+++ b/.github/workflows/rector.silverstripe_5_81.yml
@@ -42,7 +42,7 @@ jobs:
       -
         name: 'Rector (process)'
         # config uses base of caller module
-        run: vendor/bin/rector process --no-diffs --ansi --config vendor/nswdpc/ci-files/rector/.rector.silverstripe_5_81.php
+        run: vendor/bin/rector process --no-diffs --ansi --config vendor/nswdpc/ci-files/rector/.rector.silverstripe_5_81.php src tests
 
       -
         # commit only to core contributors who have repository access

--- a/.github/workflows/rector.silverstripe_5_83.yml
+++ b/.github/workflows/rector.silverstripe_5_83.yml
@@ -42,7 +42,7 @@ jobs:
       -
         name: 'Rector (process)'
         # config uses base of caller module
-        run: vendor/bin/rector process --no-diffs --ansi --config vendor/nswdpc/ci-files/rector/.rector.silverstripe_5_83.php
+        run: vendor/bin/rector process --no-diffs --ansi --config vendor/nswdpc/ci-files/rector/.rector.silverstripe_5_83.php src tests
 
       -
         # commit only to core contributors who have repository access

--- a/.github/workflows/rector.silverstripe_5_84.yml
+++ b/.github/workflows/rector.silverstripe_5_84.yml
@@ -42,7 +42,7 @@ jobs:
       -
         name: 'Rector (process)'
         # config uses base of caller module
-        run: vendor/bin/rector process --no-diffs --ansi --config vendor/nswdpc/ci-files/rector/.rector.silverstripe_5_84.php
+        run: vendor/bin/rector process --no-diffs --ansi --config vendor/nswdpc/ci-files/rector/.rector.silverstripe_5_84.php src tests
 
       -
         # commit only to core contributors who have repository access

--- a/.github/workflows/silverstripe.yml
+++ b/.github/workflows/silverstripe.yml
@@ -43,7 +43,7 @@ jobs:
         # run unless the branch contains this label
         if: ${{ !contains(github.ref_name, 'no-cs-fix') }}
         # config uses base of caller module
-        run: vendor/bin/php-cs-fixer fix --ansi --no-interaction --show-progress=none --config vendor/nswdpc/ci-files/php-cs-fixer/.php-cs-fixer.php
+        run: vendor/bin/php-cs-fixer fix --ansi --no-interaction --show-progress=none --config vendor/nswdpc/ci-files/php-cs-fixer/.php-cs-fixer.php src tests
 
       -
         # commit only to core contributors who have repository access

--- a/.github/workflows/silverstripe.yml
+++ b/.github/workflows/silverstripe.yml
@@ -57,7 +57,7 @@ jobs:
         # run unless the branch contains this label
         if: ${{ !contains(github.ref_name, 'no-rector') }}
         # config uses base of caller module
-        run: vendor/bin/rector process --no-diffs --ansi --config vendor/nswdpc/ci-files/rector/.rector.silverstripe.php
+        run: vendor/bin/rector process --no-diffs --ansi --config vendor/nswdpc/ci-files/rector/.rector.silverstripe.php src tests
 
       -
         # commit only to core contributors who have repository access

--- a/.github/workflows/silverstripe_53_83.yml
+++ b/.github/workflows/silverstripe_53_83.yml
@@ -43,7 +43,7 @@ jobs:
         # run unless the branch contains this label
         if: ${{ !contains(github.ref_name, 'no-cs-fix') }}
         # config uses base of caller module
-        run: vendor/bin/php-cs-fixer fix --ansi --no-interaction --show-progress=none --config vendor/nswdpc/ci-files/php-cs-fixer/.php-cs-fixer.php
+        run: vendor/bin/php-cs-fixer fix --ansi --no-interaction --show-progress=none --config vendor/nswdpc/ci-files/php-cs-fixer/.php-cs-fixer.php src tests
 
       -
         # commit only to core contributors who have repository access

--- a/.github/workflows/silverstripe_53_83.yml
+++ b/.github/workflows/silverstripe_53_83.yml
@@ -57,7 +57,7 @@ jobs:
         # run unless the branch contains this label
         if: ${{ !contains(github.ref_name, 'no-rector') }}
         # config uses base of caller module
-        run: vendor/bin/rector process --no-diffs --ansi --config vendor/nswdpc/ci-files/rector/.rector.silverstripe_53_83.php
+        run: vendor/bin/rector process --no-diffs --ansi --config vendor/nswdpc/ci-files/rector/.rector.silverstripe_53_83.php src tests
 
       -
         # commit only to core contributors who have repository access

--- a/.github/workflows/silverstripe_5_81.yml
+++ b/.github/workflows/silverstripe_5_81.yml
@@ -43,7 +43,7 @@ jobs:
         # run unless the branch contains this label
         if: ${{ !contains(github.ref_name, 'no-cs-fix') }}
         # config uses base of caller module
-        run: vendor/bin/php-cs-fixer fix --ansi --no-interaction --show-progress=none --config vendor/nswdpc/ci-files/php-cs-fixer/.php-cs-fixer.php
+        run: vendor/bin/php-cs-fixer fix --ansi --no-interaction --show-progress=none --config vendor/nswdpc/ci-files/php-cs-fixer/.php-cs-fixer.php src tests
 
       -
         # commit only to core contributors who have repository access

--- a/.github/workflows/silverstripe_5_81.yml
+++ b/.github/workflows/silverstripe_5_81.yml
@@ -57,7 +57,7 @@ jobs:
         # run unless the branch contains this label
         if: ${{ !contains(github.ref_name, 'no-rector') }}
         # config uses base of caller module
-        run: vendor/bin/rector process --no-diffs --ansi --config vendor/nswdpc/ci-files/rector/.rector.silverstripe_5_81.php
+        run: vendor/bin/rector process --no-diffs --ansi --config vendor/nswdpc/ci-files/rector/.rector.silverstripe_5_81.php src tests
 
       -
         # commit only to core contributors who have repository access

--- a/.github/workflows/silverstripe_5_83.yml
+++ b/.github/workflows/silverstripe_5_83.yml
@@ -43,7 +43,7 @@ jobs:
         # run unless the branch contains this label
         if: ${{ !contains(github.ref_name, 'no-cs-fix') }}
         # config uses base of caller module
-        run: vendor/bin/php-cs-fixer fix --ansi --no-interaction --show-progress=none --config vendor/nswdpc/ci-files/php-cs-fixer/.php-cs-fixer.php
+        run: vendor/bin/php-cs-fixer fix --ansi --no-interaction --show-progress=none --config vendor/nswdpc/ci-files/php-cs-fixer/.php-cs-fixer.php src tests
 
       -
         # commit only to core contributors who have repository access

--- a/.github/workflows/silverstripe_5_83.yml
+++ b/.github/workflows/silverstripe_5_83.yml
@@ -57,7 +57,7 @@ jobs:
         # run unless the branch contains this label
         if: ${{ !contains(github.ref_name, 'no-rector') }}
         # config uses base of caller module
-        run: vendor/bin/rector process --no-diffs --ansi --config vendor/nswdpc/ci-files/rector/.rector.silverstripe_5_83.php
+        run: vendor/bin/rector process --no-diffs --ansi --config vendor/nswdpc/ci-files/rector/.rector.silverstripe_5_83.php src tests
 
       -
         # commit only to core contributors who have repository access

--- a/.github/workflows/silverstripe_5_84.yml
+++ b/.github/workflows/silverstripe_5_84.yml
@@ -43,7 +43,7 @@ jobs:
         # run unless the branch contains this label
         if: ${{ !contains(github.ref_name, 'no-cs-fix') }}
         # config uses base of caller module
-        run: vendor/bin/php-cs-fixer fix --ansi --no-interaction --show-progress=none --config vendor/nswdpc/ci-files/php-cs-fixer/.php-cs-fixer.php
+        run: vendor/bin/php-cs-fixer fix --ansi --no-interaction --show-progress=none --config vendor/nswdpc/ci-files/php-cs-fixer/.php-cs-fixer.php src tests
 
       -
         # commit only to core contributors who have repository access

--- a/.github/workflows/silverstripe_5_84.yml
+++ b/.github/workflows/silverstripe_5_84.yml
@@ -57,7 +57,7 @@ jobs:
         # run unless the branch contains this label
         if: ${{ !contains(github.ref_name, 'no-rector') }}
         # config uses base of caller module
-        run: vendor/bin/rector process --no-diffs --ansi --config vendor/nswdpc/ci-files/rector/.rector.silverstripe_5_84.php
+        run: vendor/bin/rector process --no-diffs --ansi --config vendor/nswdpc/ci-files/rector/.rector.silverstripe_5_84.php src tests
 
       -
         # commit only to core contributors who have repository access

--- a/php-cs-fixer/.php-cs-fixer.php
+++ b/php-cs-fixer/.php-cs-fixer.php
@@ -3,10 +3,7 @@
  * Configuration file for https://github.com/PHP-CS-Fixer/PHP-CS-Fixer
  */
 $finder = PhpCsFixer\Finder::create()
-            ->in([
-                'src',
-                'tests',
-            ]);
+            ->in(__DIR__);
 
 $config = new PhpCsFixer\Config();
 return $config->setRules([

--- a/rector/.rector.silverstripe.php
+++ b/rector/.rector.silverstripe.php
@@ -25,8 +25,7 @@ return $builder
     ])
 
     ->withPaths([
-        'src/',
-        'tests/'
+        __DIR__
     ])
 
     ->withSkip(

--- a/rector/.rector.silverstripe_53_83.php
+++ b/rector/.rector.silverstripe_53_83.php
@@ -25,8 +25,7 @@ return $builder
     ])
 
     ->withPaths([
-        'src/',
-        'tests/'
+        __DIR__
     ])
 
     ->withSkip(

--- a/rector/.rector.silverstripe_5_81.php
+++ b/rector/.rector.silverstripe_5_81.php
@@ -25,8 +25,7 @@ return $builder
     ])
 
     ->withPaths([
-        'src/',
-        'tests/'
+        __DIR__
     ])
 
     ->withSkip(

--- a/rector/.rector.silverstripe_5_83.php
+++ b/rector/.rector.silverstripe_5_83.php
@@ -25,8 +25,7 @@ return $builder
     ])
 
     ->withPaths([
-        'src/',
-        'tests/'
+        __DIR__
     ])
 
     ->withSkip(

--- a/rector/.rector.silverstripe_5_84.php
+++ b/rector/.rector.silverstripe_5_84.php
@@ -25,8 +25,7 @@ return $builder
     ])
 
     ->withPaths([
-        'src/',
-        'tests/'
+        __DIR__
     ])
 
     ->withSkip(


### PR DESCRIPTION
## Changes

+ php-cs-fixer: use `__DIR__` for Finder->in()  to allow paths to be specified in command
+ rector: use `__DIR__` in withPaths() to allow paths to be specified in command
+ Update workflows to specify src and tests path by default